### PR TITLE
FIXED - incorrect grey language button

### DIFF
--- a/src/Multilingual.php
+++ b/src/Multilingual.php
@@ -36,10 +36,16 @@ class Multilingual extends Field
         $locales = $this->getLocales();
         $result = [];
         foreach ($locales as $key => $locale) {
+            $isTranslated = false;
+            foreach($resource->getTranslatableAttributes() as $value) {
+                $isTranslated = in_array($key, array_keys($resource->getTranslations($value)));
+                if($isTranslated) break;
+            }
+            
             $result[] = [
                 'label' => $locale,
                 'value' => $key,
-                'translated' => in_array($key, array_keys($resource->getTranslations($resource->getTranslatableAttributes()[0])))
+                'translated' => $isTranslated
             ];
         }
 


### PR DESCRIPTION
Hello,

If the first translatable field is not fill, the language button is in grey while others fields are filled.

This commit correct this bug. 

Thanks for the package :)
